### PR TITLE
feat(common): add rules to prefer modern syntax

### DIFF
--- a/common.js
+++ b/common.js
@@ -57,7 +57,10 @@ module.exports = {
     'no-var': 'error',
     'no-underscore-dangle': 'off',
     'no-extra-parens': 'off',
-    'no-fallthrough': 'off'
+    'no-fallthrough': 'off',
+    'prefer-const': 'error',
+    'prefer-rest-params': 'error',
+    'prefer-spread': 'error'
   },
   overrides: [],
   parserOptions: {

--- a/common.js
+++ b/common.js
@@ -55,12 +55,13 @@ module.exports = {
     'no-spaced-func': 'error',
     'no-trailing-spaces': 'error',
     'no-var': 'error',
-    'no-underscore-dangle': 'off',
-    'no-extra-parens': 'off',
-    'no-fallthrough': 'off',
     'prefer-const': 'error',
     'prefer-rest-params': 'error',
-    'prefer-spread': 'error'
+    'prefer-spread': 'error',
+
+    'no-underscore-dangle': 'off',
+    'no-extra-parens': 'off',
+    'no-fallthrough': 'off'
   },
   overrides: [],
   parserOptions: {


### PR DESCRIPTION
We prefer const, reset and spread params because they result in more
readable, clear code.