### PR TITLE
chore: array-callback-returns should be an error

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -4,7 +4,7 @@ module.exports = {
   extends: ['@autovance/eslint-config-autovance/common'],
   plugins: [],
   rules: {
-    'array-callback-return': 'warn',
+    'array-callback-return': 'error',
     'one-var': ['error', 'never'],
     strict: ['error', 'global'],
     'dot-notation': [


### PR DESCRIPTION
we should always return from array prototype methods