### PR TITLE
feat: disable typescript no-unused-vars

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -14,6 +14,7 @@ module.exports = {
     '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-parameter-properties': 'off',
-    '@typescript-eslint/explicit-function-return-type': 'off'
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/no-unused-vars': 'off'
   }
 };


### PR DESCRIPTION
Already handled by based no-unused-vars