### PR TITLE
fix: turn off no-unused-vars for hybrid projects

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,10 @@
 module.exports = {
   extends: [
     '@autovance/eslint-config-autovance/common',
-    '@autovance/eslint-config-autovance/typescript',
-    '@autovance/eslint-config-autovance/javascript'
+    '@autovance/eslint-config-autovance/javascript',
+    '@autovance/eslint-config-autovance/typescript'
   ],
   rules: {
-    '@typescript-eslint/no-var-requires': 'off'
+    '@typescript-eslint/no-var-requires': 'off' // conflicts with JS
   }
 };

--- a/index.js
+++ b/index.js
@@ -6,7 +6,14 @@ module.exports = {
     '@autovance/eslint-config-autovance/javascript',
     '@autovance/eslint-config-autovance/typescript'
   ],
-  rules: {
-    '@typescript-eslint/no-var-requires': 'off' // conflicts with JS
-  }
+  rules: {},
+  overrides: [
+    {
+      files: ['*.js'],
+      rules: {
+        '@typescript-eslint/no-var-requires': 'off',
+        'constructor-super': 'error'
+      }
+    }
+  ]
 };

--- a/typescript.js
+++ b/typescript.js
@@ -14,7 +14,6 @@ module.exports = {
     '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-parameter-properties': 'off',
-    '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/no-unused-vars': 'off'
+    '@typescript-eslint/explicit-function-return-type': 'off'
   }
 };


### PR DESCRIPTION
This is duplicated by the typescript rules, and typescript is more
accurate for this even in cases of regular javascript.

Prevents type interface files from being flagged red all over.