### PR TITLE
Merge pull request #8 from autovance/no-return-await

### DIFF
--- a/common.js
+++ b/common.js
@@ -55,6 +55,8 @@ module.exports = {
     'no-spaced-func': 'error',
     'no-trailing-spaces': 'error',
     'no-var': 'error',
+    'no-return-await': 'error',
+
     'prefer-const': 'error',
     'prefer-rest-params': 'error',
     'prefer-spread': 'error',


### PR DESCRIPTION
A 35% increase in performance is seen by avoiding `return await`.