### PR TITLE
feat: require-await

### DIFF
--- a/common.js
+++ b/common.js
@@ -56,6 +56,7 @@ module.exports = {
     'no-trailing-spaces': 'error',
     'no-var': 'error',
     'no-return-await': 'error',
+    'require-await': 'error',
 
     'prefer-const': 'error',
     'prefer-rest-params': 'error',

--- a/common.js
+++ b/common.js
@@ -56,7 +56,7 @@ module.exports = {
     'no-trailing-spaces': 'error',
     'no-var': 'error',
     'no-return-await': 'error',
-    'require-await': 'error',
+    'require-await': 'warning',
 
     'prefer-const': 'error',
     'prefer-rest-params': 'error',

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
       rules: {
         '@typescript-eslint/no-var-requires': 'off', // JS conflict
         'constructor-super': 'error',
-        'require-await': 'error' // TS disablesthis  as it can report incorrectly for ts
+        'require-await': 'error' // TS disables this  as it can report incorrectly for ts
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
       rules: {
         '@typescript-eslint/no-var-requires': 'off', // JS conflict
         'constructor-super': 'error',
-        'require-await': 'error' // TS disables this  as it can report incorrectly for ts
+        'require-await': 'warning' // TS disables this as it can report incorrectly for ts
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -11,8 +11,9 @@ module.exports = {
     {
       files: ['*.js'],
       rules: {
-        '@typescript-eslint/no-var-requires': 'off',
-        'constructor-super': 'error'
+        '@typescript-eslint/no-var-requires': 'off', // JS conflict
+        'constructor-super': 'error',
+        'require-await': 'error' // TS disablesthis  as it can report incorrectly for ts
       }
     }
   ]

--- a/typescript.js
+++ b/typescript.js
@@ -16,6 +16,6 @@ module.exports = {
     '@typescript-eslint/no-parameter-properties': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     'require-await': 'off', // must disable the base rule as it can report incorrect errors
-    '@typescript-eslint/require-await': 'error'
+    '@typescript-eslint/require-await': 'warning'
   }
 };

--- a/typescript.js
+++ b/typescript.js
@@ -14,6 +14,8 @@ module.exports = {
     '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-parameter-properties': 'off',
-    '@typescript-eslint/explicit-function-return-type': 'off'
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    'require-await': 'off', // must disable the base rule as it can report incorrect errors
+    '@typescript-eslint/require-await': 'error'
   }
 };


### PR DESCRIPTION
Disallow functions that are `async` but do not use await. This builds
off of the `no-return-await` by removing another unneeded promise wrap.

https://eslint.org/docs/rules/require-await

Warning: this will not catch functions that return two types, ie.
promise / or empty array. In this case, the developer will have to be
concious of the return type and use try+catch to handle the promise
error and utilize await.