### PR TITLE
Merge pull request #10 from autovance/disallow-promise-catch

### DIFF
--- a/common.js
+++ b/common.js
@@ -12,9 +12,10 @@ module.exports = {
     'prettier/prettier': 'error',
 
     'no-restricted-syntax': [
-      'error',
+      'warn',
       { selector: "MethodDefinition[kind='set']", message: 'Property setters are not allowed' },
-      { selector: "MethodDefinition[kind='get']", message: 'Property getters are not allowed' }
+      { selector: "MethodDefinition[kind='get']", message: 'Property getters are not allowed' },
+      { selector: 'MemberExpression > Identifier[name="catch"]', message: 'Promise catch is not allowed. Use try/catch with async/await.' }
     ],
 
     yoda: 'error',
@@ -65,17 +66,6 @@ module.exports = {
     'no-extra-parens': 'off',
     'no-fallthrough': 'off'
   },
-  overrides: [
-    {
-      files: ['*.js', '*.ts'],
-      rules: {
-        'no-restricted-syntax': [
-          'warn',
-          { selector: 'MemberExpression > Identifier[name="catch"]', message: 'Promise catch is not allowed. Use try/catch with async/await.' }
-        ]
-      }
-    }
-  ],
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module',

--- a/common.js
+++ b/common.js
@@ -65,7 +65,17 @@ module.exports = {
     'no-extra-parens': 'off',
     'no-fallthrough': 'off'
   },
-  overrides: [],
+  overrides: [
+    {
+      files: ['*.js', '*.ts'],
+      rules: {
+        'no-restricted-syntax': [
+          'warn',
+          { selector: 'MemberExpression > Identifier[name="catch"]', message: 'Promise catch is not allowed. Use try/catch with async/await.' }
+        ]
+      }
+    }
+  ],
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module',


### PR DESCRIPTION
Indicates a `.catch()` call as a warning to use async/await instead.

This is implemented as an override as `no-restricted-syntax` cannot mix warnings and errors.