### PR TITLE
fix: allow optional chaining method calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ module.exports = {
       rules: {
         '@typescript-eslint/no-var-requires': 'off', // JS conflict
         'constructor-super': 'error',
-        'require-await': 'warn' // TS disables this as it can report incorrectly for ts
+        'require-await': 'warn', // TS disables this as it can report incorrectly for ts
+        'no-unused-expressions': 'off', // Replace no-unused-expressions with typescript rule to allow optional chaining on method calls
       }
     }
   ]


### PR DESCRIPTION
In hybrid projects, disable `no-unused-expressions` in favour of `@typescript-eslint/no-unused-expressions`.

This allows typescript to call methods that may not exist via optional chaining.

```ts
const x = {}
x?.y();
```