### PR TITLE
fix: correctly override unused-expressions rule in ts

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,11 @@ module.exports = {
         '@typescript-eslint/no-var-requires': 'off', // JS conflict
         'constructor-super': 'error',
         'require-await': 'warn', // TS disables this as it can report incorrectly for ts
+      }
+    },
+    {
+      files: ['*.ts'],
+      rules: {
         'no-unused-expressions': 'off', // Replace no-unused-expressions with typescript rule to allow optional chaining on method calls
       }
     }


### PR DESCRIPTION
This rule needs to be turned off in .ts files, not .js files