### PR TITLE
feat: allow equality operator when comparing to null

### DIFF
--- a/common.js
+++ b/common.js
@@ -25,7 +25,7 @@ module.exports = {
     'consistent-return': 'warn',
 
     // Base TS&JS Safety
-    eqeqeq: 'error',
+    eqeqeq: ['error', 'always', {null: 'ignore'}],
     'no-eval': 'error',
     'no-with': 'error',
     'no-alert': 'error',


### PR DESCRIPTION
When comparing `null` with the equality operator, it will only be true if comparing to `null` or `undefined`. This can act as a "nil" check: `if (x === undefined || x === null)` -> `(if x == null)`.

See:
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Equality
- https://eslint.org/docs/rules/eqeqeq