### PR TITLE
feat: add 'prefer-includes' to the ts style

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -15,7 +15,9 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-parameter-properties': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off'
-
+    
+    "@typescript-eslint/prefer-includes': 'on'
+    
     // This rule was proposed but is too slow because of the typescript parser requirement.
     // 'require-await': 'off', // must disable the base rule as it can report incorrect errors
     // '@typescript-eslint/require-await': 'warn'

--- a/typescript.js
+++ b/typescript.js
@@ -16,7 +16,7 @@ module.exports = {
     '@typescript-eslint/no-parameter-properties': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off'
     
-    "@typescript-eslint/prefer-includes': 'on'
+    "@typescript-eslint/prefer-includes': 'error'
     
     // This rule was proposed but is too slow because of the typescript parser requirement.
     // 'require-await': 'off', // must disable the base rule as it can report incorrect errors


### PR DESCRIPTION
[Rule Definition](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-includes.md)

This rule nudges developers away from `~ & indexOf` and towards the `includes` method for checking the existence of a value.