### PR TITLE
feat(ts): explicit boundary types

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,7 @@ module.exports = {
       rules: {
         '@typescript-eslint/explicit-module-boundary-types': 'off', // Reports incorrectly
         '@typescript-eslint/no-var-requires': 'off', // JS conflict
-        'constructor-super': 'error',
-        'require-await': 'warn' // TS disables this as it can report incorrectly for ts
+        'constructor-super': 'error'
       }
     },
     {

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = {
     {
       files: ['*.js'],
       rules: {
+        '@typescript-eslint/explicit-module-boundary-types': 'off', // Reports incorrectly
         '@typescript-eslint/no-var-requires': 'off', // JS conflict
         'constructor-super': 'error',
         'require-await': 'warn' // TS disables this as it can report incorrectly for ts

--- a/typescript.js
+++ b/typescript.js
@@ -15,6 +15,8 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-parameter-properties': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
+
+    '@typescript-eslint/explicit-module-boundary-types': 'error',
     '@typescript-eslint/prefer-includes': 'error',
 
     '@typescript-eslint/require-await': 'warn',


### PR DESCRIPTION
**Rule Details**: https://github.com/typescript-eslint/typescript-eslint/blob/v4.4.0/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md

I want to propose using this rule to enforce explicitly typing functions that are exported at a boundary. 

The aim here is to force changes to actual types instead of implicit types - resulting in a more
cohesive typing environment. Changes to functions with explicit types are safer because you cannot accidentally change the type without visible fallout.

This does not affect local functions, which are absolutely capable of using implicit typing, and should be encouraged to do so.
