### PR TITLE
feat: add generator star spacing rules

### DIFF
--- a/common.js
+++ b/common.js
@@ -21,6 +21,8 @@ module.exports = {
       }
     ],
 
+    'yield-star-spacing': ['error', 'after'],
+
     yoda: 'error',
     'consistent-return': 'warn',
 
@@ -56,7 +58,7 @@ module.exports = {
     'no-console': 'error',
     'no-array-constructor': 'error',
     'no-new-object': 'error',
-    'no-spaced-func': 'error',
+    'func-call-spacing': ["error", "always"],
     'no-trailing-spaces': 'error',
     'no-var': 'error',
     'no-return-await': 'error',

--- a/common.js
+++ b/common.js
@@ -58,7 +58,7 @@ module.exports = {
     'no-console': 'error',
     'no-array-constructor': 'error',
     'no-new-object': 'error',
-    'func-call-spacing': ["error", "always"],
+    'func-call-spacing': ['error', 'never'],
     'no-trailing-spaces': 'error',
     'no-var': 'error',
     'no-return-await': 'error',


### PR DESCRIPTION
This removes the deprecated `no-spaced-func` rule and replaces it with `func-call-spacing` which supports
generators better.

Valid code with these rules:

```js
async function* () {}
async function() {}
```

Code not valid with these rules:

```js
async function * () {}
async function*() {}
async function () {}
```

I think this pattern allows for the best readability, and allows for easy identification of the
`*` in the generator signatures.
